### PR TITLE
Fix gallery modal content alignment [#151326182]

### DIFF
--- a/grails-app/assets/stylesheets/commons.css
+++ b/grails-app/assets/stylesheets/commons.css
@@ -66,3 +66,10 @@
     /* Matching the card padding of Bootstrap 4. */
     margin-bottom: 1.25rem;
 }
+
+/**
+ * Override Bootstrap 4's flex-end justification in ekko-lightbox's modals.
+ */
+.ekko-lightbox .modal-footer {
+    justify-content: flex-start;
+}


### PR DESCRIPTION
Add common style fix for ekko-lightbox and bootstrap 4's `modal-footer` conflict.